### PR TITLE
Add CI and data integrity tests for SMILES

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on: [ push, pull_request ]
+
+jobs:
+  lint:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.10" ]
+        tox-env: [ "mypy", "flake8", "py" ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip setuptools wheel
+          pip install tox
+      - name: Check manifest
+        run: tox -e ${{ matrix.tox-env }}

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Mac OS files
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ data = db[db.Name=='phenol']
 ```
 to load the database and extract all data with a molecule named phenol
 
+## Maintenance
+
+This repository has data quality assurance tests implemented in Python that
+can be run with `tox` using the following commands:
+
+```shell
+$ git clone git@github.com:MobleyLab/GuthrieSolv.git
+$ cd GuthrieSolv
+$ pip install tox
+$ tox
+```
+
 ## Authors
 ### Primary author
 - J. Peter Guthrie (University of Western Ontario)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+line-length = 100
+target-version = ["py38", "py39", "py310"]
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+include_trailing_comma = true
+reverse_relative = true

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -28,16 +28,17 @@ class TestData(unittest.TestCase):
         """Test all SMILES can be parsed."""
         dd = defaultdict(list)
         names = {}
-        missing = []
+        missing = {}
         for idx, (smiles, name) in self.df[["mol", "Name"]].iterrows():
             if pd.isna(smiles):
-                missing.append(idx)
+                missing[idx] = name
             else:
                 dd[smiles].append(idx)
                 names[smiles] = name
 
-        with self.subTest(smiles="MISSING"):
-            self.assertEqual(0, len(missing), msg=f"Lines missing SMILES: {missing}")
+        for idx, name in sorted(missing.items()):
+            with self.subTest(name=name, smiles="MISSING", line=idx):
+                self.fail(msg=f"Lines missing SMILES: {missing}")
 
         for smiles, lines in sorted(dd.items()):
             with self.subTest(name=names[smiles], smiles=smiles):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -30,18 +30,19 @@ class TestData(unittest.TestCase):
         names = {}
         missing = {}
         for idx, (smiles, name) in self.df[["mol", "Name"]].iterrows():
+            file_idx = idx + 2
             if pd.isna(smiles):
-                missing[idx] = name
+                missing[file_idx] = name
             else:
-                dd[smiles].append(idx)
+                dd[smiles].append(file_idx)
                 names[smiles] = name
 
-        for idx, name in sorted(missing.items()):
-            with self.subTest(name=name, smiles="MISSING", line=idx):
+        for file_idx, name in sorted(missing.items()):
+            with self.subTest(name=name, smiles="MISSING", line=file_idx):
                 self.fail(msg=f"Lines missing SMILES: {missing}")
 
         for smiles, lines in sorted(dd.items()):
-            with self.subTest(name=names[smiles], smiles=smiles):
+            with self.subTest(name=names[smiles].strip(), smiles=smiles):
                 self.assertIsInstance(smiles, str)
                 mol = MolFromSmiles(smiles)
-                self.assertIsNotNone(mol, msg=f"Unable to parse SMILES on rows: {lines}")
+                self.assertIsNotNone(mol, msg=f"Bad smiles for {names[smiles].strip()} on rows: {lines}")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -27,18 +27,20 @@ class TestData(unittest.TestCase):
     def test_smiles(self):
         """Test all SMILES can be parsed."""
         dd = defaultdict(list)
+        names = {}
         missing = []
-        for idx, smiles in self.df["mol"].items():
+        for idx, (smiles, name) in self.df[["mol", "Name"]].iterrows():
             if pd.isna(smiles):
                 missing.append(idx)
             else:
                 dd[smiles].append(idx)
+                names[smiles] = name
 
         with self.subTest(smiles="MISSING"):
             self.assertEqual(0, len(missing), msg=f"Lines missing SMILES: {missing}")
 
         for smiles, lines in sorted(dd.items()):
-            with self.subTest(smiles=smiles):
+            with self.subTest(name=names[smiles], smiles=smiles):
                 self.assertIsInstance(smiles, str)
                 mol = MolFromSmiles(smiles)
                 self.assertIsNotNone(mol, msg=f"Unable to parse SMILES on rows: {lines}")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+"""Test data."""
+
+import unittest
+from collections import defaultdict
+from pathlib import Path
+from typing import ClassVar
+
+import pandas as pd
+from rdkit.Chem import MolFromSmiles
+
+HERE = Path(__file__).parent.resolve()
+PATH = HERE.parent.joinpath("guthrie_database.csv")
+
+
+class TestData(unittest.TestCase):
+    """A test case for checking the data."""
+
+    df: ClassVar[pd.DataFrame]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        """Prepare the test case with the data."""
+        cls.df = pd.read_csv(PATH)
+
+    def test_smiles(self):
+        """Test all SMILES can be parsed."""
+        dd = defaultdict(list)
+        missing = []
+        for idx, smiles in self.df["mol"].items():
+            if pd.isna(smiles):
+                missing.append(idx)
+            else:
+                dd[smiles].append(idx)
+
+        with self.subTest(smiles="MISSING"):
+            self.assertEqual(0, len(missing), msg=f"Lines missing SMILES: {missing}")
+
+        for smiles, lines in sorted(dd.items()):
+            with self.subTest(smiles=smiles):
+                self.assertIsInstance(smiles, str)
+                mol = MolFromSmiles(smiles)
+                self.assertIsNotNone(mol, msg=f"Unable to parse SMILES on rows: {lines}")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -45,4 +45,6 @@ class TestData(unittest.TestCase):
             with self.subTest(name=names[smiles].strip(), smiles=smiles):
                 self.assertIsInstance(smiles, str)
                 mol = MolFromSmiles(smiles)
-                self.assertIsNotNone(mol, msg=f"Bad smiles for {names[smiles].strip()} on rows: {lines}")
+                self.assertIsNotNone(
+                    mol, msg=f"Bad smiles for {names[smiles].strip()} on rows: {lines}"
+                )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,57 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist =
+    lint
+    flake8
+    mypy
+    py
+
+[testenv]
+commands =
+    python -m pytest tests/
+skip_install = true
+deps =
+    pytest
+    rdkit-pypi
+    pandas
+
+[testenv:lint]
+description = Run formatters and auto-linters to keep code looking spiffy.
+commands =
+    black tests/
+    isort tests/
+skip_install = true
+deps =
+    black
+    isort
+
+[testenv:flake8]
+description = Run the flake8 tool with several plugins (bandit, docstrings, import order, pep8 naming).
+commands =
+    flake8 --max-line-length 120 tests/
+skip_install = true
+deps =
+    darglint
+    flake8<4.0.0
+    flake8-bandit
+    flake8-black
+    flake8-bugbear
+    flake8-colors
+    flake8-docstrings
+    flake8-isort
+    flake8-print
+    pep8-naming
+    pydocstyle
+
+[testenv:mypy]
+description = Run the mypy tool to check static typing on the project.
+commands =
+    mypy --install-types --non-interactive --ignore-missing-imports tests/
+skip_install = true
+deps =
+    mypy
+    pydantic

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ commands =
 skip_install = true
 deps =
     pytest
+    pytest-subtests
     rdkit-pypi
     pandas
 


### PR DESCRIPTION
Closes #1

This PR does the following:

1. Adds a `tox.ini` file for making testing and linting reproducible from any environment
2. Adds tests for all SMILES being non-null and parsable. There are a handful of cases where this isn't true that I suggest we fix before accepting this PR
3. Adds code quality tests to make sure that the python code that goes in here stays readable and maintainable
   - `flake8` checks code quality
   - `black` automatically reformats code to look nice
   - `mypy` makes sure that code is self consistent using optional type hints
4. Adds GitHub actions configuration to make sure that these tests and code quality are run on each commit. In the future, you should not accept any contributions that break the build. I've found in my own curation projects than an excellent workflow is to make a new branch, write a test that corresponds to the curation I will do, then do the curation.

## Required curation

There is one lines which do not contain a SMILES string at all:
- 21446 (3,8-Dimethylceroxen)

I've started chipping away at the remaining issues by doing some of my own curation, but I think I'll need a bt of help for the last few (I have a background in med/synthetic chem, but they're still tricky). The CI is run at [![Tests](https://github.com/cthoyt/GuthrieSolv/actions/workflows/tests.yml/badge.svg)](https://github.com/cthoyt/GuthrieSolv/actions/workflows/tests.yml) every time I make a commit. If you accept that my PR can run GitHub actions on this repo, then you can follow the links directly at the bottom of the PR.